### PR TITLE
feat: Migrating library to support .net Maui and Mopups popup lib

### DIFF
--- a/.build/.build.csproj
+++ b/.build/.build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace></RootNamespace>
     <IsPackable>False</IsPackable>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
@@ -17,8 +17,4 @@
     <add key="format" value="0" />
     <add key="disabled" value="False" />
   </packageManagement>
-  <activePackageSource>
-    <!-- this tells that all of them are active -->
-    <add key="All" value="(Aggregate source)" />
-  </activePackageSource>
 </configuration>

--- a/Packages.props
+++ b/Packages.props
@@ -12,10 +12,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="System.Reactive" Version="4.*" />
-    <PackageReference Update="ReactiveUI.XamForms" Version="11.*" />
-    <PackageReference Update="Rg.Plugins.Popup" Version="2.*" />
-    <PackageReference Update="Xamarin.Forms" Version="4.5.*" />
-    <PackageReference Update="Xamarin.Essentials" Version="1.*" />
+    <PackageReference Update="ReactiveUI.Maui" Version="18.*" />
+    <PackageReference Update="Mopups" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('monoandroid'))">
     <PackageReference Update="Xamarin.Android.Support.Design" Version="28.0.0.1" />

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ReactiveUI.Plugins.Popup
-This provides a base implementation extending [Rg.Plugins.Popup](https://www.nuget.org/packages/Rg.Plugins.Popup/) for use with [ReactiveUI.XamForms](https://www.nuget.org/packages/ReactiveUI.XamForms/).
+This provides a base implementation extending [Moppups](https://www.nuget.org/packages/Mopups/1.1.1) for use with [ReactiveUI.Maui](https://www.nuget.org/packages/ReactiveUI.Maui).
 
 # Status
 <!-- badges -->

--- a/common.build.props
+++ b/common.build.props
@@ -9,7 +9,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/RLittlesII/ReactiveUI.Plugins.Popup</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageTags>reactiveui;xamarin.forms;popups</PackageTags>
+        <PackageTags>reactiveui;maui;popups</PackageTags>
         <PackageReleaseNotes>https://github.com/RLittlesII/ReactiveUI.Plugins.Popup/releases</PackageReleaseNotes>
     </PropertyGroup>
 </Project>

--- a/src/ReactiveUI.Plugins.Popup/INavigationExtensions.cs
+++ b/src/ReactiveUI.Plugins.Popup/INavigationExtensions.cs
@@ -1,57 +1,59 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Text;
-using Rg.Plugins.Popup.Extensions;
-using Rg.Plugins.Popup.Pages;
-using Xamarin.Forms;
+using Mopup.Pages;
+using Mopup.Services;
 
 namespace RxUI.Plugins.Popup
 {
-    /// <summary>
-    /// Extension methods for the <see cref="INavigation"/> service to interact with <see cref="PopupPage"/> objects.
-    /// </summary>
     public static class INavigationExtensions
     {
-        /// <summary>
-        /// Pops all <see cref="PopupPage"/> from the navigation.
-        /// </summary>
-        /// <param name="navigation">The navigation.</param>
-        /// <param name="animate">if set to <c>true</c> [animate].</param>
-        /// <returns>An observable sequence to signal completion.</returns>
-        public static IObservable<Unit> PopAllPopup(this INavigation navigation, bool animate = true) =>
-            Observable.FromAsync(async _ => await navigation.PopAllPopupAsync(animate).ConfigureAwait(false));
+        /// <summary>
+        /// Pops all <see cref="PopupPage"/> from the navigation.
+        /// </summary>
+        /// <param name="navigation">The navigation.</param>
+        /// <param name="animate">if set to <c>true</c> [animate].</param>
+        /// <returns>An observable sequence to signal completion.</returns>
+        public static IObservable<Unit> PopAllPopup(this INavigation navigation, bool animate = true) =>
+            Observable.FromAsync(async _ => await MopupService.Instance.PopAllAsync(animate).ConfigureAwait(false));
+
+
 
         /// <summary>
-        /// Pops the <see cref="PopupPage"/> from navigation.
-        /// </summary>
-        /// <param name="navigation">The navigation.</param>
-        /// <param name="animate">if set to <c>true</c> [animate].</param>
-        /// <returns>An observable sequence to signal completion.</returns>
+                /// Pops the <see cref="PopupPage"/> from navigation.
+                /// </summary>
+                /// <param name="navigation">The navigation.</param>
+                /// <param name="animate">if set to <c>true</c> [animate].</param>
+                /// <returns>An observable sequence to signal completion.</returns>
         public static IObservable<Unit> PopPopup(this INavigation navigation, bool animate = true) =>
-            Observable.FromAsync(async _ => await navigation.PopPopupAsync(animate).ConfigureAwait(false));
+            Observable.FromAsync(async _ => await MopupService.Instance.PopAsync(animate).ConfigureAwait(false));
+
+
 
         /// <summary>
-        /// Pushes the <see cref="PopupPage" /> onto the navigation.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="navigation">The navigation.</param>
-        /// <param name="popupPage">The popup page.</param>
-        /// <param name="animate">if set to <c>true</c> [animate].</param>
-        /// <returns>An observable sequence to signal completion.</returns>
+                /// Pushes the <see cref="PopupPage" /> onto the navigation.
+                /// </summary>
+                /// <typeparam name="T"></typeparam>
+                /// <param name="navigation">The navigation.</param>
+                /// <param name="popupPage">The popup page.</param>
+                /// <param name="animate">if set to <c>true</c> [animate].</param>
+                /// <returns>An observable sequence to signal completion.</returns>
         public static IObservable<Unit> PushPopup<T>(this INavigation navigation, T popupPage, bool animate = true)
-            where T : PopupPage => Observable.FromAsync(async _ => await navigation.PushPopupAsync(popupPage, animate).ConfigureAwait(false));
+            where T : PopupPage => Observable.FromAsync(async _ => await MopupService.Instance.PushAsync(popupPage, animate).ConfigureAwait(false));
+
+
 
         /// <summary>
-        /// Removes the <see cref="PopupPage" /> from the navigation.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="navigation">The navigation.</param>
-        /// <param name="popupPage">The popup page.</param>
-        /// <param name="animate">if set to <c>true</c> [animate].</param>
-        /// <returns>An observable sequence to signal completion.</returns>
+                /// Removes the <see cref="PopupPage" /> from the navigation.
+                /// </summary>
+                /// <typeparam name="T"></typeparam>
+                /// <param name="navigation">The navigation.</param>
+                /// <param name="popupPage">The popup page.</param>
+                /// <param name="animate">if set to <c>true</c> [animate].</param>
+                /// <returns>An observable sequence to signal completion.</returns>
         public static IObservable<Unit> RemovePopupPage<T>(this INavigation navigation, T popupPage, bool animate = true)
-            where T : PopupPage => Observable.FromAsync(async _ => await navigation.RemovePopupPageAsync(popupPage, animate).ConfigureAwait(false));
+            where T : PopupPage => Observable.FromAsync(async _ => await MopupService.Instance.RemovePageAsync(popupPage, animate).ConfigureAwait(false));
     }
 }

--- a/src/ReactiveUI.Plugins.Popup/ReactivePopupPage.cs
+++ b/src/ReactiveUI.Plugins.Popup/ReactivePopupPage.cs
@@ -2,10 +2,9 @@
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using System.Reactive.Subjects;
+using Mopups.Enums;
+using Mopups.Pages;
 using ReactiveUI;
-using Rg.Plugins.Popup.Pages;
-using Xamarin.Forms;
 
 namespace RxUI.Plugins.Popup
 {
@@ -19,7 +18,7 @@ namespace RxUI.Plugins.Popup
         /// <summary>
         /// The view model property.
         /// </summary>
-        public static readonly BindableProperty ViewModelProperty = BindableProperty.Create(
+        public new static readonly BindableProperty ViewModelProperty = BindableProperty.Create(
             nameof(ViewModel),
             typeof(TViewModel),
             typeof(IViewFor<TViewModel>),
@@ -44,7 +43,7 @@ namespace RxUI.Plugins.Popup
         /// <summary>
         /// Gets or sets the ViewModel to display.
         /// </summary>
-        public TViewModel ViewModel
+        public new TViewModel ViewModel
         {
             get => (TViewModel)GetValue(ViewModelProperty);
             set => SetValue(ViewModelProperty, value);
@@ -53,7 +52,7 @@ namespace RxUI.Plugins.Popup
         /// <summary>
         /// Gets the control binding disposable.
         /// </summary>
-        protected CompositeDisposable ControlBindings { get; } = new CompositeDisposable();
+        protected new CompositeDisposable ControlBindings { get; } = new CompositeDisposable();
 
         /// <inheritdoc/>
         protected override void OnBindingContextChanged()

--- a/src/ReactiveUI.Plugins.Popup/RxUI.Plugins.Popup.csproj
+++ b/src/ReactiveUI.Plugins.Popup/RxUI.Plugins.Popup.csproj
@@ -1,12 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net7.0</TargetFrameworks>
+		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
+		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+		<UseMaui>true</UseMaui>
+		<SingleProject>true</SingleProject>
+		<ImplicitUsings>enable</ImplicitUsings>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="ReactiveUI.XamForms" />
-    <PackageReference Include="Rg.Plugins.Popup" />
-    <PackageReference Include="Xamarin.Forms" />
-  </ItemGroup>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
+		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0-ios|AnyCPU'">
+	  <CreatePackage>false</CreatePackage>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Update="ReactiveUI.Maui" />
+		<PackageReference Update="Mopups"/>
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
Hello, 

One of my projects use this lib, and since there is no activity, I assumed that y'all were not migrating to .net Maui.

I took the liberty of copying the code locally to my project, and I made it work with ReactiveUI.Maui, Maui, and the new version of the RG.Pluging.Popups => Mopups.

On my project I was able to run and make it work, however, I'm not familiar with the setup of the build project of this lib, so I was unable to restore nuget packages and see this puppy running.

I would love some help understanding the local lib setup.

Cheers